### PR TITLE
Chore: Devcontainer and DX updates

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -3,9 +3,9 @@ version: "3.9"
 services:
   conda-repo-template:
     # Choose one
-    # image: utkusarioglu/conda-econ-devcontainer:1.0.11
-    # image: utkusarioglu/conda-math-devcontainer:1.0.11
-    # image: utkusarioglu/conda-music-devcontainer:1.0.11
+    # image: utkusarioglu/conda-econ-devcontainer:1.0.14
+    # image: utkusarioglu/conda-math-devcontainer:1.0.14
+    # image: utkusarioglu/conda-music-devcontainer:1.0.14
 
     environment:
       PYTHONPATH: /utkusarioglu-com/templates/conda-repo-template

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "elam"]
-	path = .elam
-	url = https://github.com/utkusarioglu/elam.git

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,6 +6,9 @@
       "detail": "Run tests",
       "type": "shell",
       "command": "scripts/test-monitor.sh",
+      "args": [
+        "${file}"
+      ],
       "icon": {
         "color": "terminal.ansiYellow",
         "id": "beaker"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Utku Sarioglu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line_length=79

--- a/scripts/post-create-command.sh
+++ b/scripts/post-create-command.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-.elam/update-status.sh
+${HOME}/elam/elam.sh repo status

--- a/scripts/test-monitor.sh
+++ b/scripts/test-monitor.sh
@@ -1,11 +1,74 @@
 #!/bin/bash
 
-echo "Starting watchmedo for pytest…"
-watchmedo shell-command \
-  --patterns "*.py" \
-  --recursive \
-  --command "\
-      pytest src \
-    " \
-  .
-  
+COLOR_RED="\e[31m"
+COLOR_GREEN="\e[32m"
+COLOR_NONE="\e[0m"
+
+PY_EXTENSION="py"
+UNIT_TEST_SUFFIX="unit_test"
+
+file_class="$UNIT_TEST_SUFFIX.$PY_EXTENSION"
+
+function log_error_no_param_abspath {
+  echo -e "${COLOR_RED}Error:${COLOR_NONE} First param needs to be a valid test or implementation py file path"
+}
+
+function log_error_no_implementation_abspath {
+  echo -e "${COLOR_RED}Error:${COLOR_NONE} Cannot find the implementation file"
+}
+
+function log_error_no_test_abspath {
+  echo -e "${COLOR_RED}Error:${COLOR_NONE} Cannot find the test file"
+}
+
+function log_info_starting_watchmedo {
+  echo -e "${COLOR_GREEN}Starting Watchmedo${COLOR_NONE} for '${implementation_basename}'…"
+}
+
+function main {
+  param_abspath=$1
+
+  if [ -z "$param_abspath" ]; then
+    log_error_no_param_abspath
+    exit 1
+  fi
+
+  param_relpath=${param_abspath/$(pwd)\//}
+  param_basename=$(basename $param_relpath)
+  param_filename=${param_basename%.*}
+  param_dir_abspath=${param_abspath/\/$param_basename/}
+
+  implementation_filename="${param_filename/_${UNIT_TEST_SUFFIX}/}"
+  implementation_basename="$implementation_filename.$PY_EXTENSION"
+  implementation_abspath="$param_dir_abspath/$implementation_basename"
+
+  test_filename="${implementation_filename}_$UNIT_TEST_SUFFIX"
+  test_basename="$test_filename.$PY_EXTENSION"
+  test_abspath="$param_dir_abspath/$test_basename"
+
+  if [ ! -f "$implementation_abspath" ]; then
+    log_error_no_implementation_abspath
+    exit 2
+  fi
+
+  if [ ! -f  "$test_abspath" ]; then
+    log_error_no_test_abspath
+    exit 3
+  fi
+
+  log_info_starting_watchmedo
+
+  watchmedo shell-command \
+    --patterns "$test_abspath;$implementation_abspath" \
+    --recursive \
+    --wait \
+    --verbose \
+    --command '
+        if [ "${watch_event_type}" = "closed" ]; then
+          pytest '$test_abspath'
+        fi
+      '\
+    "$param_dir_abspath"
+}
+
+main $@

--- a/src/main.ipynb
+++ b/src/main.ipynb
@@ -10,7 +10,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.6 ('econ')",
+   "display_name": "Python 3.10.12 ('main')",
    "language": "python",
    "name": "python3"
   },
@@ -24,12 +24,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "7c2280d020ed2aed7cdac8de3c4dba8c6872048e6115fb0655eb08d156aeaec0"
+    "hash": "308b5f6911e3cc4ec5f0f03e686ff38b372e8b9ac3710a4a96e714469fbb5282"
    }
   }
  },


### PR DESCRIPTION
- Upgrade devcontainer versions to `1.0.14`. These new versions feature
  elam internally, and has bug fixes related to environment handling in
  micromamba and pip.
- Remove elam submodule. This is done because elam is now provided by
  the devcontainer and the repo does not need to provide its own
  instance.
- Remove `.gitmodules`. As elam is no longer offered by the repo, this
  feature is not needed.
- Update `post-create-command.sh` to use the new elam location.
- Update `test-monitor.sh`. This update is received from
  `utkusarioglu/python-repo-template`. The update allows the script to
  target a certain file and its unit test.
- Update `.vscode/tasks.json` to use the new test monitor features.
